### PR TITLE
Fix electrode tooltip

### DIFF
--- a/Source/NeuropixThread.h
+++ b/Source/NeuropixThread.h
@@ -30,7 +30,7 @@
 
 #include "NeuropixComponents.h"
 
-#define PLUGIN_VERSION "1.0.2"
+#define PLUGIN_VERSION "1.0.3"
 
 #define MINSTREAMBUFFERSIZE (1024 * 32)
 #define MAXSTREAMBUFFERSIZE (1024 * 1024 * 32)

--- a/Source/UI/ProbeBrowser.cpp
+++ b/Source/UI/ProbeBrowser.cpp
@@ -429,8 +429,8 @@ String ProbeBrowser::getElectrodeInfoString (int index)
             a += " NONE";
     }
 
-    a += ", Channel ";
-    a += String (parent->electrodeMetadata[index].channel + 1);
+    a += ", CH";
+    a += String (parent->electrodeMetadata[index].channel);
 
     a += "\nY Position: ";
     a += String (parent->electrodeMetadata[index].ypos);


### PR DESCRIPTION
Updated electrode info tooltip to match actual channel prefix and index.