### PR TITLE
feat(agent): expose read-only Neuropix inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # 2. Platform specific build related
 
 Builds/*/*
+/Build-AgentInventory*/
 
 
 # 3. OS-specific files

--- a/Source/AgentInventory.cpp
+++ b/Source/AgentInventory.cpp
@@ -86,7 +86,8 @@ std::string serializeInventory (const Inventory& inventory)
         output << ',';
         appendString (output, "serial_number", probe.serialNumber);
         output << ",\"is_calibrated\":" << (probe.calibrated ? "true" : "false")
-               << ",\"available\":" << (probe.available ? "true" : "false")
+               << ",\"supported\":" << (probe.supported ? "true" : "false")
+               << ",\"status\":\"" << probeStatusToString (probe.status) << '\"'
                << ",\"disabled\":" << (probe.disabled ? "true" : "false")
                << '}';
     }
@@ -109,6 +110,22 @@ std::string probeAutomationId (const Locator& locator)
            + ".dock_" + std::to_string (locator.dock);
 }
 
+std::string probeStatusToString (ProbeStatus status)
+{
+    switch (status)
+    {
+        case ProbeStatus::DISCONNECTED: return "DISCONNECTED";
+        case ProbeStatus::CONNECTING: return "CONNECTING";
+        case ProbeStatus::CONNECTED: return "CONNECTED";
+        case ProbeStatus::UPDATING: return "UPDATING";
+        case ProbeStatus::ACQUIRING: return "ACQUIRING";
+        case ProbeStatus::RECORDING: return "RECORDING";
+        case ProbeStatus::DISABLED: return "DISABLED";
+    }
+
+    return "UNKNOWN";
+}
+
 std::string basestationStatusText (const BasestationInventory& basestation)
 {
     return "slot=" + std::to_string (basestation.slot)
@@ -125,7 +142,8 @@ std::string probeStatusText (const ProbeInventory& probe)
            + "; type=" + probe.type
            + "; part_number=" + probe.partNumber
            + "; serial_number=" + probe.serialNumber
-           + "; available=" + (probe.available ? "true" : "false")
+           + "; supported=" + (probe.supported ? "true" : "false")
+           + "; status=" + probeStatusToString (probe.status)
            + "; disabled=" + (probe.disabled ? "true" : "false")
            + "; calibrated=" + (probe.calibrated ? "true" : "false");
 }

--- a/Source/AgentInventory.cpp
+++ b/Source/AgentInventory.cpp
@@ -1,0 +1,132 @@
+#include "AgentInventory.h"
+
+#include <iomanip>
+#include <sstream>
+
+namespace neuropix::agent
+{
+namespace
+{
+std::string escapeJson (const std::string& value)
+{
+    std::ostringstream escaped;
+
+    for (const unsigned char character : value)
+    {
+        switch (character)
+        {
+            case '\"': escaped << "\\\""; break;
+            case '\\': escaped << "\\\\"; break;
+            case '\b': escaped << "\\b"; break;
+            case '\f': escaped << "\\f"; break;
+            case '\n': escaped << "\\n"; break;
+            case '\r': escaped << "\\r"; break;
+            case '\t': escaped << "\\t"; break;
+            default:
+                if (character < 0x20)
+                    escaped << "\\u" << std::hex << std::setw (4)
+                            << std::setfill ('0') << static_cast<int> (character)
+                            << std::dec;
+                else
+                    escaped << character;
+        }
+    }
+
+    return escaped.str();
+}
+
+void appendString (std::ostringstream& output,
+                   const char* name,
+                   const std::string& value)
+{
+    output << '\"' << name << "\":\"" << escapeJson (value) << '\"';
+}
+}
+
+std::string serializeInventory (const Inventory& inventory)
+{
+    std::ostringstream output;
+    output << '{';
+    appendString (output, "plugin", inventory.plugin);
+    output << ',';
+    appendString (output, "version", inventory.version);
+    output << ",\"schema_version\":1,\"basestations\":[";
+
+    for (std::size_t index = 0; index < inventory.basestations.size(); ++index)
+    {
+        if (index != 0)
+            output << ',';
+
+        const auto& basestation = inventory.basestations[index];
+        output << "{\"slot\":" << basestation.slot << ',';
+        appendString (output, "type", basestation.type);
+        output << ',';
+        appendString (output, "part_number", basestation.partNumber);
+        output << ',';
+        appendString (output, "firmware_version", basestation.firmwareVersion);
+        output << '}';
+    }
+
+    output << "],\"probes\":[";
+
+    for (std::size_t index = 0; index < inventory.probes.size(); ++index)
+    {
+        if (index != 0)
+            output << ',';
+
+        const auto& probe = inventory.probes[index];
+        output << '{';
+        appendString (output, "name", probe.name);
+        output << ',';
+        appendString (output, "type", probe.type);
+        output << ",\"slot\":" << probe.locator.slot
+               << ",\"port\":" << probe.locator.port
+               << ",\"dock\":" << probe.locator.dock << ',';
+        appendString (output, "part_number", probe.partNumber);
+        output << ',';
+        appendString (output, "serial_number", probe.serialNumber);
+        output << ",\"is_calibrated\":" << (probe.calibrated ? "true" : "false")
+               << ",\"available\":" << (probe.available ? "true" : "false")
+               << ",\"disabled\":" << (probe.disabled ? "true" : "false")
+               << '}';
+    }
+
+    output << "]}";
+    return output.str();
+}
+
+std::string basestationAutomationId (int slot)
+{
+    return "oe.plugin.neuropix_pxi.inventory.basestation.slot_"
+           + std::to_string (slot);
+}
+
+std::string probeAutomationId (const Locator& locator)
+{
+    return "oe.plugin.neuropix_pxi.inventory.probe.slot_"
+           + std::to_string (locator.slot)
+           + ".port_" + std::to_string (locator.port)
+           + ".dock_" + std::to_string (locator.dock);
+}
+
+std::string basestationStatusText (const BasestationInventory& basestation)
+{
+    return "slot=" + std::to_string (basestation.slot)
+           + "; type=" + basestation.type
+           + "; part_number=" + basestation.partNumber
+           + "; firmware_version=" + basestation.firmwareVersion;
+}
+
+std::string probeStatusText (const ProbeInventory& probe)
+{
+    return "slot=" + std::to_string (probe.locator.slot)
+           + "; port=" + std::to_string (probe.locator.port)
+           + "; dock=" + std::to_string (probe.locator.dock)
+           + "; type=" + probe.type
+           + "; part_number=" + probe.partNumber
+           + "; serial_number=" + probe.serialNumber
+           + "; available=" + (probe.available ? "true" : "false")
+           + "; disabled=" + (probe.disabled ? "true" : "false")
+           + "; calibrated=" + (probe.calibrated ? "true" : "false");
+}
+}

--- a/Source/AgentInventory.h
+++ b/Source/AgentInventory.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace neuropix::agent
+{
+struct Locator
+{
+    int slot;
+    int port;
+    int dock;
+};
+
+struct ProbeInventory
+{
+    std::string name;
+    std::string type;
+    Locator locator;
+    std::string partNumber;
+    std::string serialNumber;
+    bool calibrated;
+    bool available;
+    bool disabled;
+};
+
+struct BasestationInventory
+{
+    int slot;
+    std::string type;
+    std::string partNumber;
+    std::string firmwareVersion;
+};
+
+struct Inventory
+{
+    std::string plugin;
+    std::string version;
+    std::vector<BasestationInventory> basestations;
+    std::vector<ProbeInventory> probes;
+};
+
+std::string serializeInventory (const Inventory& inventory);
+std::string basestationAutomationId (int slot);
+std::string probeAutomationId (const Locator& locator);
+std::string basestationStatusText (const BasestationInventory& basestation);
+std::string probeStatusText (const ProbeInventory& probe);
+}

--- a/Source/AgentInventory.h
+++ b/Source/AgentInventory.h
@@ -5,6 +5,17 @@
 
 namespace neuropix::agent
 {
+enum class ProbeStatus
+{
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED,
+    UPDATING,
+    ACQUIRING,
+    RECORDING,
+    DISABLED
+};
+
 struct Locator
 {
     int slot;
@@ -20,7 +31,8 @@ struct ProbeInventory
     std::string partNumber;
     std::string serialNumber;
     bool calibrated;
-    bool available;
+    bool supported;
+    ProbeStatus status;
     bool disabled;
 };
 
@@ -43,6 +55,7 @@ struct Inventory
 std::string serializeInventory (const Inventory& inventory);
 std::string basestationAutomationId (int slot);
 std::string probeAutomationId (const Locator& locator);
+std::string probeStatusToString (ProbeStatus status);
 std::string basestationStatusText (const BasestationInventory& basestation);
 std::string probeStatusText (const ProbeInventory& probe);
 }

--- a/Source/AgentInventoryAdapter.h
+++ b/Source/AgentInventoryAdapter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "AgentInventory.h"
+#include "NeuropixComponents.h"
+
+namespace neuropix::agent
+{
+inline ProbeStatus probeStatusFromSource (SourceStatus status)
+{
+    switch (status)
+    {
+        case SourceStatus::DISCONNECTED: return ProbeStatus::DISCONNECTED;
+        case SourceStatus::CONNECTING: return ProbeStatus::CONNECTING;
+        case SourceStatus::CONNECTED: return ProbeStatus::CONNECTED;
+        case SourceStatus::UPDATING: return ProbeStatus::UPDATING;
+        case SourceStatus::ACQUIRING: return ProbeStatus::ACQUIRING;
+        case SourceStatus::RECORDING: return ProbeStatus::RECORDING;
+        case SourceStatus::DISABLED: return ProbeStatus::DISABLED;
+    }
+
+    return ProbeStatus::DISCONNECTED;
+}
+}

--- a/Source/NeuropixEditor.cpp
+++ b/Source/NeuropixEditor.cpp
@@ -23,10 +23,27 @@
 
 #include "NeuropixEditor.h"
 
+#include "AgentInventory.h"
 #include "NeuropixCanvas.h"
 #include "NeuropixComponents.h"
 #include "NeuropixThread.h"
 #include "UI/NeuropixInterface.h"
+
+namespace
+{
+String readableBasestationType (BasestationType type)
+{
+    switch (type)
+    {
+        case BasestationType::PXI: return "PXI";
+        case BasestationType::OPTO: return "OPTO";
+        case BasestationType::ONEBOX: return "ONEBOX";
+        case BasestationType::SIMULATED: return "SIMULATED";
+    }
+
+    return "UNKNOWN";
+}
+}
 
 RefreshButton::RefreshButton() : Button ("Refresh")
 {
@@ -66,6 +83,22 @@ SlotButton::SlotButton (Basestation* bs, NeuropixThread* thread_) : Button (Stri
     thread = thread_;
     basestation = bs;
     slot = basestation->slot;
+
+    setComponentID (String (neuropix::agent::basestationAutomationId (slot)));
+    setTitle ("Neuropixels basestation inventory");
+    setDescription (String (neuropix::agent::basestationStatusText (
+        { slot,
+          readableBasestationType (basestation->type).toStdString(),
+          basestation->info.part_number.toStdString(),
+          basestation->info.boot_version.toStdString() })));
+    setHelpText ("Read-only basestation identity and status.");
+    setAccessible (true);
+}
+
+std::unique_ptr<AccessibilityHandler> SlotButton::createAccessibilityHandler()
+{
+    return std::make_unique<AccessibilityHandler> (
+        *this, AccessibilityRole::staticText);
 }
 
 void SlotButton::paintButton (Graphics& g, bool isMouseOver, bool isButtonDown)
@@ -239,7 +272,57 @@ SourceButton::SourceButton (int id_, DataSource* source_, Basestation* basestati
 
     setRadioGroupId (979);
 
+    if (sourceType == DataSourceType::PROBE)
+    {
+        auto* probe = static_cast<Probe*> (dataSource);
+        const neuropix::agent::Locator locator {
+            probe->basestation->slot, probe->headstage->port, probe->dock
+        };
+        setComponentID (String (neuropix::agent::probeAutomationId (locator)));
+        setTitle ("Neuropixels probe inventory");
+        setHelpText ("Read-only probe identity and status.");
+        setAccessible (true);
+        updateInventoryAccessibilityStatus();
+    }
+
     startTimer (500); // update probe status and fifo monitor every 500 ms
+}
+
+void SourceButton::updateInventoryAccessibilityStatus()
+{
+    if (sourceType != DataSourceType::PROBE || dataSource == nullptr)
+        return;
+
+    auto* probe = static_cast<Probe*> (dataSource);
+    const neuropix::agent::Locator locator {
+        probe->basestation->slot, probe->headstage->port, probe->dock
+    };
+    const bool disabled = ! probe->isEnabled
+                          || probe->getStatus() == SourceStatus::DISABLED;
+    const String statusText (neuropix::agent::probeStatusText (
+        { probe->displayName.toStdString(),
+          probe->probeMetadata.name.toStdString(),
+          locator,
+          probe->info.part_number.toStdString(),
+          std::to_string (probe->info.serial_number),
+          probe->isCalibrated,
+          probe->isValid,
+          disabled }));
+
+    if (getDescription() != statusText)
+    {
+        setDescription (statusText);
+        invalidateAccessibilityHandler();
+    }
+}
+
+std::unique_ptr<AccessibilityHandler> SourceButton::createAccessibilityHandler()
+{
+    if (sourceType == DataSourceType::PROBE)
+        return std::make_unique<AccessibilityHandler> (
+            *this, AccessibilityRole::staticText);
+
+    return ToggleButton::createAccessibilityHandler();
 }
 
 void SourceButton::setSelectedState (bool state)
@@ -354,6 +437,7 @@ void SourceButton::timerCallback()
     if (dataSource != nullptr)
     {
         setSourceStatus (dataSource->getStatus());
+        updateInventoryAccessibilityStatus();
     }
 }
 

--- a/Source/NeuropixEditor.cpp
+++ b/Source/NeuropixEditor.cpp
@@ -23,7 +23,7 @@
 
 #include "NeuropixEditor.h"
 
-#include "AgentInventory.h"
+#include "AgentInventoryAdapter.h"
 #include "NeuropixCanvas.h"
 #include "NeuropixComponents.h"
 #include "NeuropixThread.h"
@@ -307,6 +307,7 @@ void SourceButton::updateInventoryAccessibilityStatus()
           std::to_string (probe->info.serial_number),
           probe->isCalibrated,
           probe->isValid,
+          neuropix::agent::probeStatusFromSource (probe->getStatus()),
           disabled }));
 
     if (getDescription() != statusText)

--- a/Source/NeuropixEditor.h
+++ b/Source/NeuropixEditor.h
@@ -76,6 +76,9 @@ public:
     /** Destructor */
     ~SlotButton() {}
 
+    /** Exposes inventory as read-only UIA text, not as an invokable button. */
+    std::unique_ptr<AccessibilityHandler> createAccessibilityHandler() override;
+
     bool isEnabled;
 
 private:
@@ -157,6 +160,9 @@ public:
     /** Checks whether the status has changed */
     void timerCallback();
 
+    /** Exposes probe inventory as read-only UIA text, not as a toggle. */
+    std::unique_ptr<AccessibilityHandler> createAccessibilityHandler() override;
+
     DataSource* dataSource;
     Basestation* basestation;
     bool connected;
@@ -166,6 +172,9 @@ public:
 private:
     /** Draws the button */
     void paintButton (Graphics& g, bool isMouseOver, bool isButtonDown);
+
+    /** Updates read-only status text without changing the stable UIA ID. */
+    void updateInventoryAccessibilityStatus();
 
     SourceStatus status;
     DataSourceType sourceType;

--- a/Source/NeuropixThread.cpp
+++ b/Source/NeuropixThread.cpp
@@ -23,7 +23,7 @@
 
 #include "NeuropixThread.h"
 #include "NeuropixEditor.h"
-#include "AgentInventory.h"
+#include "AgentInventoryAdapter.h"
 
 #include "Basestations/OneBox.h"
 #include "Basestations/PxiBasestation.h"
@@ -750,6 +750,7 @@ String NeuropixThread::getProbeInfoString()
                                       std::to_string (probe->info.serial_number),
                                       probe->isCalibrated,
                                       probe->isValid,
+                                      neuropix::agent::probeStatusFromSource (probe->getStatus()),
                                       disabled });
     }
 

--- a/Source/NeuropixThread.cpp
+++ b/Source/NeuropixThread.cpp
@@ -23,6 +23,7 @@
 
 #include "NeuropixThread.h"
 #include "NeuropixEditor.h"
+#include "AgentInventory.h"
 
 #include "Basestations/OneBox.h"
 #include "Basestations/PxiBasestation.h"
@@ -35,6 +36,22 @@
 
 //Helpful for debugging when PXI system is connected but don't want to connect to real probes
 #define FORCE_SIMULATION_MODE false
+
+namespace
+{
+std::string basestationTypeName (BasestationType type)
+{
+    switch (type)
+    {
+        case BasestationType::PXI: return "PXI";
+        case BasestationType::OPTO: return "OPTO";
+        case BasestationType::ONEBOX: return "ONEBOX";
+        case BasestationType::SIMULATED: return "SIMULATED";
+    }
+
+    return "UNKNOWN";
+}
+}
 
 DataThread* NeuropixThread::createDataThread (SourceNode* sn, DeviceType type)
 {
@@ -707,39 +724,36 @@ Array<Probe*> NeuropixThread::getProbes()
 
 String NeuropixThread::getProbeInfoString()
 {
-    DynamicObject output;
+    neuropix::agent::Inventory inventory;
+    inventory.plugin = "Neuropix-PXI";
+    inventory.version = PLUGIN_VERSION;
 
-    output.setProperty (Identifier ("plugin"),
-                        var ("Neuropix-PXI"));
-    output.setProperty (Identifier ("version"),
-                        var (PLUGIN_VERSION));
-
-    Array<var> probes;
+    for (auto basestation : getBasestations())
+    {
+        inventory.basestations.push_back ({ basestation->slot,
+                                            basestationTypeName (basestation->type),
+                                            basestation->info.part_number.toStdString(),
+                                            basestation->info.boot_version.toStdString() });
+    }
 
     for (auto probe : getProbes())
     {
-        DynamicObject::Ptr p = new DynamicObject();
+        const bool disabled = ! probe->isEnabled
+                              || probe->getStatus() == SourceStatus::DISABLED;
 
-        p->setProperty (Identifier ("name"), probe->displayName);
-        p->setProperty (Identifier ("type"), probe->probeMetadata.name);
-        p->setProperty (Identifier ("slot"), probe->basestation->slot);
-        p->setProperty (Identifier ("port"), probe->headstage->port);
-        p->setProperty (Identifier ("dock"), probe->dock);
-
-        p->setProperty (Identifier ("part_number"), probe->info.part_number);
-        p->setProperty (Identifier ("serial_number"), String (probe->info.serial_number));
-
-        p->setProperty (Identifier ("is_calibrated"), probe->isCalibrated);
-
-        probes.add (p.get());
+        inventory.probes.push_back ({ probe->displayName.toStdString(),
+                                      probe->probeMetadata.name.toStdString(),
+                                      { probe->basestation->slot,
+                                        probe->headstage->port,
+                                        probe->dock },
+                                      probe->info.part_number.toStdString(),
+                                      std::to_string (probe->info.serial_number),
+                                      probe->isCalibrated,
+                                      probe->isValid,
+                                      disabled });
     }
 
-    output.setProperty (Identifier ("probes"), probes);
-
-    MemoryOutputStream f;
-    output.writeAsJSON (f, JSON::FormatOptions {}.withIndentLevel (0).withSpacing (JSON::Spacing::singleLine).withMaxDecimalPlaces (4));
-
-    return f.toString();
+    return String (neuropix::agent::serializeInventory (inventory));
 }
 
 Array<DataSource*> NeuropixThread::getDataSources()

--- a/Tests/AgentInventoryTests.cpp
+++ b/Tests/AgentInventoryTests.cpp
@@ -1,0 +1,117 @@
+#include "AgentInventory.h"
+
+#include <iostream>
+#include <set>
+#include <string>
+
+namespace
+{
+int failures = 0;
+
+void expectEqual (const std::string& actual,
+                  const std::string& expected,
+                  const char* testName)
+{
+    if (actual == expected)
+        return;
+
+    ++failures;
+    std::cerr << "FAIL " << testName << "\nexpected: " << expected
+              << "\nactual:   " << actual << "\n";
+}
+
+void expectTrue (bool condition, const char* testName)
+{
+    if (condition)
+        return;
+
+    ++failures;
+    std::cerr << "FAIL " << testName << "\n";
+}
+}
+
+int main()
+{
+    using namespace neuropix::agent;
+
+    Inventory inventory;
+    inventory.plugin = "Neuropix-PXI";
+    inventory.version = "2.1.1";
+    inventory.basestations.push_back ({ 2, "PXI", "BS-0001", "3.0226" });
+    inventory.probes.push_back ({ "Probe-A",
+                                  "Neuropixels 2.0 Single Shank",
+                                  { 2, 1, 2 },
+                                  "PRB2_1_2_0640_0",
+                                  "123456789",
+                                  true,
+                                  true,
+                                  false });
+
+    const std::string expectedJson =
+        "{\"plugin\":\"Neuropix-PXI\",\"version\":\"2.1.1\",\"schema_version\":1,"
+        "\"basestations\":[{\"slot\":2,\"type\":\"PXI\",\"part_number\":\"BS-0001\","
+        "\"firmware_version\":\"3.0226\"}],\"probes\":[{\"name\":\"Probe-A\","
+        "\"type\":\"Neuropixels 2.0 Single Shank\",\"slot\":2,\"port\":1,\"dock\":2,"
+        "\"part_number\":\"PRB2_1_2_0640_0\",\"serial_number\":\"123456789\","
+        "\"is_calibrated\":true,\"available\":true,\"disabled\":false}]}";
+    expectEqual (serializeInventory (inventory),
+                 expectedJson,
+                 "golden JSON preserves NP INFO and exposes read-only inventory");
+
+    Inventory escaped;
+    escaped.plugin = "Neuropix-\"PXI\"";
+    escaped.version = "2.1.1\npreview";
+    expectEqual (serializeInventory (escaped),
+                 "{\"plugin\":\"Neuropix-\\\"PXI\\\"\",\"version\":\"2.1.1\\npreview\","
+                 "\"schema_version\":1,\"basestations\":[],\"probes\":[]}",
+                 "serializer JSON-escapes readable device strings");
+
+    const Locator first { 2, 1, 1 };
+    const Locator secondDock { 2, 1, 2 };
+    const Locator secondPort { 2, 2, 1 };
+    const Locator secondSlot { 3, 1, 1 };
+
+    const auto firstId = probeAutomationId (first);
+    expectEqual (firstId,
+                 "oe.plugin.neuropix_pxi.inventory.probe.slot_2.port_1.dock_1",
+                 "probe UIA ID is namespaced and locator based");
+    expectEqual (probeAutomationId (first),
+                 firstId,
+                 "probe UIA ID is stable for the same locator");
+
+    const std::set<std::string> probeIds {
+        firstId,
+        probeAutomationId (secondDock),
+        probeAutomationId (secondPort),
+        probeAutomationId (secondSlot)
+    };
+    expectTrue (probeIds.size() == 4,
+                "probe UIA IDs are unique across slot port dock locators");
+
+    expectEqual (basestationAutomationId (2),
+                 "oe.plugin.neuropix_pxi.inventory.basestation.slot_2",
+                 "basestation UIA ID is namespaced and slot based");
+    expectTrue (basestationAutomationId (2) != basestationAutomationId (3),
+                "basestation UIA IDs are unique across slots");
+    expectTrue (basestationAutomationId (2) != firstId,
+                "basestation and probe namespaces cannot collide");
+
+    const auto status = probeStatusText (inventory.probes.front());
+    expectEqual (status,
+                 "slot=2; port=1; dock=2; type=Neuropixels 2.0 Single Shank; "
+                 "part_number=PRB2_1_2_0640_0; serial_number=123456789; "
+                 "available=true; disabled=false; calibrated=true",
+                 "probe UIA dynamic status is readable separately from its stable ID");
+    expectEqual (basestationStatusText (inventory.basestations.front()),
+                 "slot=2; type=PXI; part_number=BS-0001; firmware_version=3.0226",
+                 "basestation UIA status exposes only source-backed readable fields");
+    expectTrue (firstId.find ("available") == std::string::npos
+                    && firstId.find ("calibrated") == std::string::npos,
+                "probe UIA stable ID excludes dynamic status values");
+
+    if (failures != 0)
+        return 1;
+
+    std::cout << "PASS 11 inventory contract checks\n";
+    return 0;
+}

--- a/Tests/AgentInventoryTests.cpp
+++ b/Tests/AgentInventoryTests.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <set>
 #include <string>
+#include <utility>
 
 namespace
 {
@@ -45,6 +46,7 @@ int main()
                                   "123456789",
                                   true,
                                   true,
+                                  ProbeStatus::CONNECTED,
                                   false });
 
     const std::string expectedJson =
@@ -53,7 +55,8 @@ int main()
         "\"firmware_version\":\"3.0226\"}],\"probes\":[{\"name\":\"Probe-A\","
         "\"type\":\"Neuropixels 2.0 Single Shank\",\"slot\":2,\"port\":1,\"dock\":2,"
         "\"part_number\":\"PRB2_1_2_0640_0\",\"serial_number\":\"123456789\","
-        "\"is_calibrated\":true,\"available\":true,\"disabled\":false}]}";
+        "\"is_calibrated\":true,\"supported\":true,\"status\":\"CONNECTED\","
+        "\"disabled\":false}]}";
     expectEqual (serializeInventory (inventory),
                  expectedJson,
                  "golden JSON preserves NP INFO and exposes read-only inventory");
@@ -100,18 +103,34 @@ int main()
     expectEqual (status,
                  "slot=2; port=1; dock=2; type=Neuropixels 2.0 Single Shank; "
                  "part_number=PRB2_1_2_0640_0; serial_number=123456789; "
-                 "available=true; disabled=false; calibrated=true",
+                 "supported=true; status=CONNECTED; disabled=false; calibrated=true",
                  "probe UIA dynamic status is readable separately from its stable ID");
     expectEqual (basestationStatusText (inventory.basestations.front()),
                  "slot=2; type=PXI; part_number=BS-0001; firmware_version=3.0226",
                  "basestation UIA status exposes only source-backed readable fields");
-    expectTrue (firstId.find ("available") == std::string::npos
+    expectTrue (firstId.find ("supported") == std::string::npos
+                    && firstId.find ("status") == std::string::npos
                     && firstId.find ("calibrated") == std::string::npos,
                 "probe UIA stable ID excludes dynamic status values");
+
+    const std::pair<ProbeStatus, const char*> statuses[] {
+        { ProbeStatus::DISCONNECTED, "DISCONNECTED" },
+        { ProbeStatus::CONNECTING, "CONNECTING" },
+        { ProbeStatus::CONNECTED, "CONNECTED" },
+        { ProbeStatus::UPDATING, "UPDATING" },
+        { ProbeStatus::ACQUIRING, "ACQUIRING" },
+        { ProbeStatus::RECORDING, "RECORDING" },
+        { ProbeStatus::DISABLED, "DISABLED" }
+    };
+
+    for (const auto& [value, expected] : statuses)
+        expectEqual (probeStatusToString (value),
+                     expected,
+                     "every official SourceStatus has a stable string");
 
     if (failures != 0)
         return 1;
 
-    std::cout << "PASS 11 inventory contract checks\n";
+    std::cout << "PASS 18 inventory contract checks\n";
     return 0;
 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(NeuropixAgentInventoryTests LANGUAGES CXX)
+
+enable_testing()
+
+add_executable(neuropix_agent_inventory_tests
+    AgentInventoryTests.cpp
+    ../Source/AgentInventory.cpp
+)
+
+target_compile_features(neuropix_agent_inventory_tests PRIVATE cxx_std_17)
+target_include_directories(neuropix_agent_inventory_tests PRIVATE ../Source)
+
+add_test(NAME neuropix_agent_inventory_contract
+         COMMAND neuropix_agent_inventory_tests)


### PR DESCRIPTION
## Summary

- extend legacy `NP INFO` with a versioned, read-only inventory schema
- expose basestation identity and probe support/status without changing scan or acquisition behavior
- add stable Windows UIA IDs based only on slot/port/dock locators
- expose inventory controls as `staticText` with no Invoke or Toggle mutation pattern

## Compatibility

Based exactly on official Neuropix-PXI `2.1.1@8c2d85a2ace63fd873b1f74fb7516a660b30562d`. Existing `NP INFO` keys and types remain unchanged: plugin, version, probes, name, type, slot, port, dock, part_number, serial_number as string, and is_calibrated.

New read-only fields are `schema_version`, `basestations`, probe `supported`, exact seven-state `status`, and `disabled`. Stable IDs exclude all dynamic status values.

## TDD evidence

- RED: missing serializer implementation failed configuration
- RED: empty serializer/UIA stubs failed golden JSON, escaping, namespace, uniqueness, and dynamic-state separation checks
- review RED: `available` incorrectly represented part-number support
- RED: missing support/status mapping failed compilation, then all seven status mappings failed with an empty stub
- GREEN: Release contract tests pass all 18 checks

## Verification

- Windows Release contract CTest: 1/1
- full Windows Release plugin build: passed
- `git diff --check`: clean
- independent re-review: READY; no Critical/Important findings

## Remaining gates

The DLL was compiled but not installed or loaded. No PXI/probe scan, live `NP INFO`, Windows UIA Inspector, acquisition, or recording hardware test was run. Upstream issue #50 remains open and reports `STATUS_HEAP_CORRUPTION` in plugin load/background scan paths; this PR does not claim that issue resolved.

No mutation, firmware, BIST, rescan, sync, Survey, preset, acquisition, or recording feature is included.
